### PR TITLE
Feature/torch svd

### DIFF
--- a/pysemtools/rom/pod.py
+++ b/pysemtools/rom/pod.py
@@ -19,7 +19,7 @@ class POD:
         global_updates=True,
         auto_expand=False,
         auto_expand_from_these_modes=1,
-        bckend = "torch",
+        bckend = "numpy",
     ):
 
         # Initialize parameters

--- a/pysemtools/rom/pod.py
+++ b/pysemtools/rom/pod.py
@@ -19,6 +19,7 @@ class POD:
         global_updates=True,
         auto_expand=False,
         auto_expand_from_these_modes=1,
+        bckend = "torch",
     ):
 
         # Initialize parameters
@@ -42,7 +43,8 @@ class POD:
 
         # Instant the math functions that will help
         self.log = logger_c(comm=comm, module_name="pod")
-        self.svd = spSVD_c(self.log)
+        self.bckend = bckend
+        self.svd = spSVD_c(self.log, self.bckend)
         self.math = math_ops_c()
 
         # Number of updates

--- a/pysemtools/rom/svd.py
+++ b/pysemtools/rom/svd.py
@@ -137,6 +137,15 @@ class SVD:
         """perform a global svd that contains all necesary rotations
         for global modes"""
 
+        if self.bckend == 'numpy':
+            return self.gbl_svd_numpy(xi, comm)
+        elif self.bckend == 'torch':
+            return self.gbl_svd_torch(xi, comm)
+    
+    def gbl_svd_numpy(self, xi, comm):
+        """perform a global svd that contains all necesary rotations
+        for global modes"""
+
         # Get information from the communicator
         rank = comm.Get_rank()
         size = comm.Get_size()
@@ -181,10 +190,91 @@ class SVD:
         # Now matrix multiply each ui by the corresponding entries in uy
         self.log.write("debug", "Performing rotations: local -> global modes")
         u_local = ui @ uy[rank * m : (rank + 1) * m, :]
+        
+        return u_local, dy, vty
+    
+    def gbl_svd_torch(self, xi, comm):
+
+        """Perform a global SVD using PyTorch, including necessary rotations for global modes."""
+        
+        # Ensure xi is a torch tensor on self.device with proper dtype
+        if not torch.is_tensor(xi):
+            self.log.write("debug", "Converting xi to a torch tensor")
+            if isinstance(xi, np.ndarray):
+                xi = torch.from_numpy(xi)
+            else:
+                xi = torch.tensor(xi)
+            xi = xi.to(device=self.device)
+        
+        # Get MPI rank and size
+        rank = comm.Get_rank()
+        size = comm.Get_size()
+
+        # Get dimensions
+        m = xi.shape[1]
+
+        # Perform SVD on each rank independently
+        self.log.write("debug", "Performing individual SVD in each rank")
+        ui, di, vti = torch.linalg.svd(xi, full_matrices=False)
+        self.log.write("debug", "Calculated eigen matrices in each rank")
+
+        yi = torch.diag(di) @ vti
+
+        # Prepare buffer for gathering on rank 0
+        y = None
+        self.log.write("debug", "Gathering combined eigen matrix in rank 0")
+        if rank == 0:
+            y = torch.empty((m * size, m), dtype=xi.dtype, device=xi.device)
+        
+        # Gather yi into y at rank 0; ensure tensors are on CPU for MPI compatibility
+        yi_cpu = yi.cpu()
+        y_cpu = None
+        if rank == 0:
+            y_cpu = torch.empty((m * size, m), dtype=yi.dtype)
+        
+        comm.Gather(yi_cpu.numpy(), y_cpu.numpy() if y_cpu is not None else None, root=0)
+
+        if rank == 0:
+            # Move gathered tensor back to the original device
+            y = torch.tensor(y_cpu, device=xi.device)
+
+        self.log.write("debug", "Performing SVD of combined eigen matrix in rank 0")
+        if rank == 0:
+            uy, dy, vty = torch.linalg.svd(y, full_matrices=False)
+        else:
+            # Prepare buffers for broadcast
+            uy = torch.empty((m * size, m), dtype=xi.dtype, device=xi.device)
+            dy = torch.empty((m,), dtype=torch.double, device=xi.device)
+            vty = torch.empty((m, m), dtype=xi.dtype, device=xi.device)
+
+        self.log.write("debug", "Broadcasting SVD(y) results")
+        comm.Bcast(uy.cpu().numpy(), root=0)
+        comm.Bcast(dy.cpu().numpy(), root=0)
+        comm.Bcast(vty.cpu().numpy(), root=0)
+
+        # Move received tensors back to original device
+        uy = torch.tensor(uy.numpy(), device=xi.device)
+        dy = torch.tensor(dy.numpy(), device=xi.device)
+        vty = torch.tensor(vty.numpy(), device=xi.device)
+
+        # Compute local rotations
+        self.log.write("debug", "Performing rotations: local -> global modes")
+        u_local = ui @ uy[rank * m : (rank + 1) * m, :]
 
         return u_local, dy, vty
 
     def gbl_update(self, u_1t, d_1t, vt_1t, xi, k, comm):
+        """
+        Method to update the global svds from a batch of data
+        No need to delete xi, as this comes from a buffer that is pre allocated
+        """
+
+        if self.bckend == 'numpy':
+            return self.gbl_update_numpy(u_1t, d_1t, vt_1t, xi, k, comm)
+        elif self.bckend == 'torch':
+            return self.gbl_update_torch(u_1t, d_1t, vt_1t, xi, k, comm)
+
+    def gbl_update_numpy(self, u_1t, d_1t, vt_1t, xi, k, comm):
         """
         Method to update the global svds from a batch of data
         No need to delete xi, as this comes from a buffer that is pre allocated
@@ -216,5 +306,67 @@ class SVD:
             u_1t = np.copy(u_1t[:, 0:k])
             d_1t = np.copy(d_1t[0:k])
             vt_1t = np.copy(vt_1t[0:k, :])
+
+        return u_1t, d_1t, vt_1t
+
+    def gbl_update_torch(self, u_1t, d_1t, vt_1t, xi, k, comm):
+        """
+        """
+        
+        # Check if xi is a torch tensor. If not, cast it and set a flag.
+        input_was_numpy = False
+        if not torch.is_tensor(xi):
+            self.log.write("debug", "Converting input xi from numpy to torch tensor")
+            input_was_numpy = True
+            if isinstance(xi, np.ndarray):
+                xi = torch.from_numpy(xi)
+            else:
+                xi = torch.tensor(xi)
+            xi = xi.to(device=self.device)
+        
+        # Also check if u_1t, d_1t, vt_1t are provided and are tensors. If not, convert them.
+        if u_1t is not None and not torch.is_tensor(u_1t):
+            u_1t = torch.from_numpy(u_1t).to(device=self.device)
+        if d_1t is not None and not torch.is_tensor(d_1t):
+            d_1t = torch.from_numpy(d_1t).to(device=self.device)
+        if vt_1t is not None and not torch.is_tensor(vt_1t):
+            vt_1t = torch.from_numpy(vt_1t).to(device=self.device)
+
+        if u_1t is None:
+            self.log.write("info", "Initialized the updating arrays")
+            u_1t, d_1t, vt_1t = self.gbl_svd(xi, comm)
+        else:
+            # Perform SVD of the new snapshot.
+            self.log.write("debug", "Performing global SVD #1 in update")
+            u_tp1, d_tp1, vt_tp1 = self.gbl_svd(xi, comm)
+            
+            # Construct the block-diagonal matrix from the conjugate transposes of vt_1t and vt_tp1.
+            self.log.write("debug", "Appending Vt matrix in update")
+            v_tilde = torch.block_diag(vt_1t.conj().T, vt_tp1.conj().T)
+            
+            # Concatenate the updated basis from previous and new snapshots.
+            self.log.write("debug", "Appending New basis to previous ones in update")
+            w = torch.cat((u_1t @ torch.diag(d_1t), u_tp1 @ torch.diag(d_tp1)), dim=1)
+            
+            # Perform SVD on the combined matrix.
+            self.log.write("debug", "Performing global SVD #2 in update")
+            uw, dw, vtw = self.gbl_svd(w, comm)
+            
+            # Update the variables.
+            u_1t = uw
+            d_1t = dw
+            vt_1t = (v_tilde @ vtw.conj().T).conj().T
+
+        # Truncate the matrices if the number of columns is larger than k.
+        if u_1t.shape[1] >= k:
+            u_1t = u_1t[:, :k].clone()
+            d_1t = d_1t[:k].clone()
+            vt_1t = vt_1t[:k, :].clone()
+
+        # If the original input was a numpy array, convert outputs back to numpy.
+        if input_was_numpy:
+            u_1t = u_1t.cpu().numpy()
+            d_1t = d_1t.cpu().numpy()
+            vt_1t = vt_1t.cpu().numpy()
 
         return u_1t, d_1t, vt_1t

--- a/pysemtools/rom/svd.py
+++ b/pysemtools/rom/svd.py
@@ -2,6 +2,10 @@
 
 import numpy as np
 import scipy.optimize
+import importlib
+if importlib.util.find_spec('torch') is not None:
+    import torch
+import sys
 
 NoneType = type(None)
 
@@ -9,7 +13,7 @@ NoneType = type(None)
 class SVD:
     """Class used to obtain parallel and streaming SVD results"""
 
-    def __init__(self, logger):
+    def __init__(self, logger, bckend="numpy"):
 
         self.log = logger
         self.ifget_all_modes = False
@@ -17,6 +21,13 @@ class SVD:
             "debug",
             "ifget_all_modes is hard coded to False. This parameter applies to lcl updates. It controls if one gets all modes in the global rotation, despite keeping less modes locally. I do not see a use for this in production runs. Thus it is set to false. If needed, activate in mpi_spSVD.py module",
         )
+
+        self.bckend = bckend
+        if bckend == 'torch':
+
+            if sys.modules.get("torch") is None:
+                raise ImportError("torch is not installed. Please install it to use the torch backend.")
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     def lcl_to_gbl_svd(self, uii, dii, vtii, k_set, comm):
         """Perform rotations to obtain global modes from local modes.

--- a/scripts/2-rom/3-pod-sem_mesh/inputs.json
+++ b/scripts/2-rom/3-pod-sem_mesh/inputs.json
@@ -5,14 +5,16 @@
 "keep_modes"         : 100,
 "write_modes"        : 10,
 "fields"             : [0,1,2],
+"dtype"              : "single",
+"backend"            : "numpy",
 "IO":{
 	"mesh_data": {
-		"dataPath" : "/home/adperez/software/pySEMTools/examples/data/sem_data/instantaneous/cylinder_rbc_nelv_600/",
+		"dataPath" : "/home/adperezm/software/pySEMTools/examples/data/sem_data/instantaneous/cylinder_rbc_nelv_600/",
 		"casename"           : "field",
 		"first_index"        : 801
 	},
 	"field_data": {
-		"dataPath" : "/home/adperez/software/pySEMTools/examples/data/sem_data/instantaneous/cylinder_rbc_nelv_600/",
+		"dataPath" : "/home/adperezm/software/pySEMTools/examples/data/sem_data/instantaneous/cylinder_rbc_nelv_600/",
 		"casename"           : "field",
 		"first_index"        : 801
 	}


### PR DESCRIPTION
This add torch support for the SVDs. This is usefull for the POD module. Here I just modified SVD and left pod pretty much unchanged. So the buffer from IO helper will be in numpy, i.e., cpu. Changing that would not really be such a problem.

Right now, svd update will check if the input is a tensor, if not it will cast it at start and return to numpy at the end. So changing the buffer later would not impact svd, I think.

Important! IF SOMETHING BREAKS ON POD, REVERT TO THE STATUS BEFORE THIS. However, if the tests pass, everything should be alright with numpy.