### PR TITLE
Small bug fix for reading adios2 compressed files that do not contain a mesh

### DIFF
--- a/pysemtools/io/adios2/compress.py
+++ b/pysemtools/io/adios2/compress.py
@@ -367,9 +367,10 @@ def read_field(comm, fname="compressed_field0.f00001"):
     else:
         dc.lz = 1
 
+    data_to_process = len(variable_data)
+    
     process_counter = 0
     if variable_names[0] == "x":
-        data_to_process = len(variable_data)
         # Initialize a new mesh object
         x = variable_data[process_counter].reshape((dc.nelv, dc.lz, dc.ly, dc.lx))
         process_counter += 1


### PR DESCRIPTION
I ran into this small bug while messing around with adios2 compression. When reading from a compressed file where there is no mesh to read, the variable `data_to_process` is never initialized. The fix here seems to work!